### PR TITLE
skip confirmation dialog w/ --force

### DIFF
--- a/config/database-synchronizer.php
+++ b/config/database-synchronizer.php
@@ -6,4 +6,5 @@ return [
     'tables' => [],
     'skip_tables' => [],
     'limit' => 5000,
+    'force' => false,
 ];

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ db:sync
 { --st|skip-tables=* : Skip given table(s) }
 { --l|limit= : Limit query rows (defaults to 5000) }
 { --truncate : Truncate before inserting data }
+{ --force : Skip confirmation dialog }
 ```
 
 ## Change log

--- a/src/Commands/Synchronise.php
+++ b/src/Commands/Synchronise.php
@@ -22,6 +22,7 @@ class Synchronise extends Command
         { --l|limit= : Limit query rows (defaults to 5000) }
         { --m|migrate : Run migrations before synchronization }
         { --truncate : Truncate before inserting data }
+        { --force : Skip confirmation dialog }
     ';
 
     /**

--- a/src/DatabaseSynchronizer.php
+++ b/src/DatabaseSynchronizer.php
@@ -22,6 +22,7 @@ class DatabaseSynchronizer
     public $from;
     public $to;
     public $truncate;
+    public $force;
 
     private $fromDB;
     private $toDB;
@@ -45,12 +46,16 @@ class DatabaseSynchronizer
         $originHost = $this->fromDB->getConfig()['host'];
         $targetHost = $this->toDB->getConfig()['host'];
 
-        if ($this->cli->confirm("Target host is set to $targetHost, continue?")) {
-            $this->feedback("origin($originHost) => target($targetHost)", 'line');
-        } else {
-            $this->feedback('Canceled!', 'warn');
+        $force = $this->force ?? config('database-synchronizer.force');
 
-            return;
+        if (!$force) {
+            if ($this->cli->confirm("Target host is set to $targetHost, continue?")) {
+                $this->feedback("origin($originHost) => target($targetHost)", 'line');
+            } else {
+                $this->feedback('Canceled!', 'warn');
+
+                return;
+            }
         }
 
         if ($this->migrate) {


### PR DESCRIPTION
With passing --force you can skip confirmation dialog yes/no.

I needed this future, coz calling command from code with `--no-interaction` does not working, it returns Canceled.